### PR TITLE
Small updates to server plugin behavior and cleanup

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/client/task/GenerateClientLibrariesTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/client/task/GenerateClientLibrariesTask.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Endpoints task to download a discovery document from the endpoints service
+ * Endpoints task to download a client library from the endpoints service
  */
 public class GenerateClientLibrariesTask extends DefaultTask {
   private File clientLibraryDir;

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateClientLibsTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateClientLibsTask.java
@@ -81,8 +81,7 @@ public class GenerateClientLibsTask extends DefaultTask {
   @TaskAction
   void generateClientLibs() throws Exception {
 
-    getProject().delete(clientLibDir);
-    clientLibDir.mkdirs();
+    // This action intentionally does not clean the output directory
 
     String classpath = (getProject().getConvention().getPlugin(JavaPluginConvention.class)
         .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath())

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateClientLibsTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateClientLibsTask.java
@@ -81,7 +81,11 @@ public class GenerateClientLibsTask extends DefaultTask {
   @TaskAction
   void generateClientLibs() throws Exception {
 
-    // This action intentionally does not clean the output directory
+    // We do *not* delete the output directory for this task, and we do *not* ensure that is clean.
+    // If the user specifies an output directory that is outside the gradle buildDir we don't want
+    // to accidentally delete anything. Since this task is not a dependency for any other task,
+    // having builds write new versions of client libraries to the output directory doesn't really
+    // affect anything.
 
     String classpath = (getProject().getConvention().getPlugin(JavaPluginConvention.class)
         .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath())

--- a/src/test/resources/projects/clientserver/server/build.gradle
+++ b/src/test/resources/projects/clientserver/server/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.0.0"
+    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.1.0"
   }
 }
 
@@ -24,7 +24,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "com.google.endpoints:endpoints-framework:2.0.0-beta.12"
+  compile "com.google.endpoints:endpoints-framework:2.0.0"
   compile "com.google.appengine:appengine-api-1.0-sdk:+" // use latest
   compile 'javax.servlet:servlet-api:2.5'
   compile 'javax.inject:javax.inject:1'

--- a/src/test/resources/projects/server/build.gradle
+++ b/src/test/resources/projects/server/build.gradle
@@ -20,7 +20,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.0.0"
+    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.1.0"
   }
 }
 
@@ -40,7 +40,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "com.google.endpoints:endpoints-framework:2.0.0-beta.12"
+  compile "com.google.endpoints:endpoints-framework:2.0.0"
   compile 'javax.servlet:servlet-api:2.5'
   compile 'javax.inject:javax.inject:1'
 }


### PR DESCRIPTION
- Make server:endpointsClientLibs NOT delete output directory since
  it is customizable, this does not affect the behavior of the
  client side (which still deletes the output directory and is not
  customizable because it's part of the client code generation
  chain)
- Update test project build dependencies
- Clean up a comment