### PR TITLE
Add hostname option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,15 +21,12 @@ version = '1.0.0-SNAPSHOT'
 
 repositories {
   mavenCentral()
-  maven {
-    url 'https://oss.sonatype.org/content/repositories/snapshots'
-  }
 }
 
 dependencies {
   compile localGroovy()
   compile gradleApi()
-  compile "com.google.endpoints:endpoints-framework-tools:2.0.5"
+  compile "com.google.endpoints:endpoints-framework-tools:2.0.7"
   compile "com.google.guava:guava:19.0"
 
   testCompile 'commons-io:commons-io:2.4'

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/EndpointsServerExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/EndpointsServerExtension.java
@@ -32,6 +32,7 @@ public class EndpointsServerExtension {
 
   private File clientLibDir;
   private List<String> serviceClasses;
+  private String hostname;
 
   public EndpointsServerExtension(Project project) {
     this.project = project;
@@ -60,4 +61,11 @@ public class EndpointsServerExtension {
     this.serviceClasses = serviceClasses;
   }
 
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname(String hostname) {
+    this.hostname = hostname;
+  }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/EndpointsServerPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/EndpointsServerPlugin.java
@@ -95,6 +95,7 @@ public class EndpointsServerPlugin implements Plugin<Project> {
                     .getClassesDir();
                 genDiscoveryDocs.setClassesDir(classesDir);
                 genDiscoveryDocs.setDiscoveryDocDir(extension.getDiscoveryDocDir());
+                genDiscoveryDocs.setHostname(extension.getHostname());
                 genDiscoveryDocs.setServiceClasses(extension.getServiceClasses());
                 genDiscoveryDocs.setWebAppDir(
                     project.getConvention().getPlugin(WarPluginConvention.class).getWebAppDir());
@@ -121,6 +122,7 @@ public class EndpointsServerPlugin implements Plugin<Project> {
                     .getClassesDir();
                 genClientLibs.setClassesDir(classesDir);
                 genClientLibs.setClientLibDir(extension.getClientLibDir());
+                genClientLibs.setHostname(extension.getHostname());
                 genClientLibs.setServiceClasses(extension.getServiceClasses());
                 genClientLibs.setWebAppDir(
                     project.getConvention().getPlugin(WarPluginConvention.class).getWebAppDir());

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateClientLibsTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateClientLibsTask.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.gradle.endpoints.framework.server.task;
 
 import com.google.api.server.spi.tools.EndpointsTool;
 import com.google.api.server.spi.tools.GetClientLibAction;
+import com.google.common.base.Strings;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,6 +27,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
@@ -36,11 +38,13 @@ import org.gradle.api.tasks.TaskAction;
  * same gradle project, use EndpointsClientPlugin
  */
 public class GenerateClientLibsTask extends DefaultTask {
-  // classes is only for detecting that the project has changed
+  // classesDir is only for detecting that the project has changed
   private File classesDir;
+
   private File clientLibDir;
-  private File webAppDir;
+  private String hostname;
   private List<String> serviceClasses;
+  private File webAppDir;
 
   @InputDirectory
   public File getClassesDir() {
@@ -78,6 +82,16 @@ public class GenerateClientLibsTask extends DefaultTask {
     this.serviceClasses = serviceClasses;
   }
 
+  @Input
+  @Optional
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname(String hostname) {
+    this.hostname = hostname;
+  }
+
   @TaskAction
   void generateClientLibs() throws Exception {
 
@@ -98,6 +112,10 @@ public class GenerateClientLibsTask extends DefaultTask {
         "-l", "java",
         "-bs", "gradle",
         "-w", webAppDir.getPath()));
+    if (!Strings.isNullOrEmpty(hostname)) {
+      params.add("-h");
+      params.add(hostname);
+    }
     params.addAll(serviceClasses);
 
     new EndpointsTool().execute(params.toArray(new String[params.size()]));

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateDiscoveryDocsTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateDiscoveryDocsTask.java
@@ -17,6 +17,7 @@ package com.google.cloud.tools.gradle.endpoints.framework.server.task;
 
 import com.google.api.server.spi.tools.EndpointsTool;
 import com.google.api.server.spi.tools.GetDiscoveryDocAction;
+import com.google.common.base.Strings;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
@@ -33,12 +35,13 @@ import org.gradle.api.tasks.TaskAction;
  * Endpoints task to download a discovery document from the endpoints service
  */
 public class GenerateDiscoveryDocsTask extends DefaultTask {
-  // classes is only for detecting that the project has changed
+  // classesDir is only for detecting that the project has changed
   private File classesDir;
+
   private File discoveryDocDir;
-  private File webAppDir;
+  private String hostname;
   private List<String> serviceClasses;
-  private String format;
+  private File webAppDir;
 
   @InputDirectory
   public File getClassesDir() {
@@ -76,6 +79,16 @@ public class GenerateDiscoveryDocsTask extends DefaultTask {
     this.serviceClasses = serviceClasses;
   }
 
+  @Optional
+  @Input
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname(String hostname) {
+    this.hostname = hostname;
+  }
+
   @TaskAction
   void generateDiscoveryDocs() throws Exception {
     getProject().delete(discoveryDocDir);
@@ -90,6 +103,10 @@ public class GenerateDiscoveryDocsTask extends DefaultTask {
         "-o", discoveryDocDir.getPath(),
         "-cp", classpath,
         "-w", webAppDir.getPath()));
+    if (!Strings.isNullOrEmpty(hostname)) {
+      params.add("-h");
+      params.add(hostname);
+    }
     params.addAll(getServiceClasses());
 
     new EndpointsTool().execute(params.toArray(new String[params.size()]));

--- a/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/ProjectTests.java
+++ b/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/ProjectTests.java
@@ -16,19 +16,32 @@
 
 package com.google.cloud.tools.gradle.endpoints.framework;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+import com.google.common.io.Files;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.util.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-
 public class ProjectTests {
+
+  private static final String DEFAULT_URL = "https://myapi.appspot.com/_ah/api";
+  private static final String DEFAULT_URL_PREFIX = "public static final String DEFAULT_ROOT_URL = ";
+  private static final String DEFAULT_URL_VARIABLE = DEFAULT_URL_PREFIX + "\"https://myapi.appspot.com/_ah/api/\";";
+  private static final String CLIENT_LIB_PATH = "build/endpointsClientLibs/testApi-v1-java.zip";
+  private static final String DISC_DOC_PATH = "build/endpointsDiscoveryDocs/testApi-v1-rest.discovery";
+  private static final String API_JAVA_FILE_PATH = "testApi/src/main/java/com/example/testApi/TestApi.java";
 
   @Rule
   public final TemporaryFolder testProjectDir = new TemporaryFolder();
@@ -67,14 +80,65 @@ public class ProjectTests {
         .withPluginClasspath()
         .withArguments("endpointsClientLibs", "endpointsDiscoveryDocs")
         .build();
-    // client lib geneneration actually generates a discovery doc as well, so check the
-    // above directory for that
-    File clientLibRoot = new File(testProjectDir.getRoot(), "/build/endpointsClientLibs");
-    Assert.assertTrue(new File(clientLibRoot, "testApi-v1-java.zip").exists());
-    Assert.assertEquals(1, clientLibRoot.listFiles().length);
 
-    File discoveryDocRoot = new File(testProjectDir.getRoot(), "/build/endpointsDiscoveryDocs");
-    Assert.assertTrue(new File(discoveryDocRoot, "testApi-v1-rest.discovery").exists());
-    Assert.assertEquals(1, discoveryDocRoot.listFiles().length);
+    File discoveryDoc = new File(testProjectDir.getRoot(), DISC_DOC_PATH);
+    Assert.assertTrue(discoveryDoc.exists());
+    Assert.assertEquals(1, discoveryDoc.getParentFile().listFiles().length);
+    String discovery = Files.toString(discoveryDoc, Charsets.UTF_8);
+    Assert.assertThat(discovery, CoreMatchers.containsString(DEFAULT_URL));
+
+    File clientLib = new File(testProjectDir.getRoot(), CLIENT_LIB_PATH);
+    Assert.assertTrue(clientLib.exists());
+    Assert.assertEquals(1, clientLib.getParentFile().listFiles().length);
+    String apiJavaFile = getFileContentsInZip(clientLib, API_JAVA_FILE_PATH);
+    Assert.assertThat(apiJavaFile, CoreMatchers.containsString(DEFAULT_URL_VARIABLE));
+  }
+
+  @Test
+  public void testServerWithHostname() throws IOException, URISyntaxException {
+    FileUtils.copyDirectory(
+        new File(getClass().getClassLoader().getResource("projects/server").toURI()),
+        testProjectDir.getRoot());
+    injectConfiguration(testProjectDir.getRoot(), "endpointsServer.hostname = 'my.hostname.com'");
+    BuildResult buildResult = GradleRunner.create()
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("endpointsClientLibs", "endpointsDiscoveryDocs")
+        .build();
+
+
+    File discoveryDoc = new File(testProjectDir.getRoot(), DISC_DOC_PATH);
+    String discovery = Files.toString(discoveryDoc, Charsets.UTF_8);
+    Assert.assertThat(discovery, CoreMatchers.not(CoreMatchers.containsString(DEFAULT_URL)));
+    Assert.assertThat(discovery, CoreMatchers.containsString("https://my.hostname.com/_ah/api"));
+
+    File clientLib = new File(testProjectDir.getRoot(), CLIENT_LIB_PATH);
+    String apiJavaFile = getFileContentsInZip(clientLib, API_JAVA_FILE_PATH);
+    Assert.assertThat(apiJavaFile, CoreMatchers.not(CoreMatchers.containsString(DEFAULT_URL_VARIABLE)));
+    Assert.assertThat(apiJavaFile, CoreMatchers.containsString(DEFAULT_URL_PREFIX + "\"https://my.hostname.com/_ah/api/\";"));
+  }
+
+  // inject a endpoints plugin configuration into the pom.xml
+  private File injectConfiguration(File root, String configuration) throws IOException {
+    File pom = new File(root, "build.gradle");
+    String pomContents = FileUtils.readFileToString(pom);
+    pomContents = pomContents.replaceAll("/\\*endpoints-plugin-configuration\\*/", configuration);
+    FileUtils.writeStringToFile(pom, pomContents);
+    return root;
+  }
+
+  // inject an application tag into the appengine-web.xml
+  private File injectApplicationId(File root, String application) throws IOException {
+    File app = new File(root, "src/main/webapp/WEB-INF/appengine-web.xml");
+    String appContents = FileUtils.readFileToString(app);
+    appContents = appContents.replaceAll("<!--application-->", application);
+    FileUtils.writeStringToFile(app, appContents);
+    return root;
+  }
+
+  private String getFileContentsInZip(File zipFile, String path) throws IOException {
+    ZipFile zip = new ZipFile(zipFile);
+    InputStream is = zip.getInputStream(zip.getEntry(path));
+    return CharStreams.toString(new InputStreamReader(is, Charsets.UTF_8));
   }
 }

--- a/src/test/resources/projects/clientserver/server/build.gradle
+++ b/src/test/resources/projects/clientserver/server/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.1.0"
+    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.3.0"
   }
 }
 
@@ -24,7 +24,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "com.google.endpoints:endpoints-framework:2.0.0"
+  compile "com.google.endpoints:endpoints-framework:2.0.7" // use latest
   compile "com.google.appengine:appengine-api-1.0-sdk:+" // use latest
   compile 'javax.servlet:servlet-api:2.5'
   compile 'javax.inject:javax.inject:1'

--- a/src/test/resources/projects/clientserver/server/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/test/resources/projects/clientserver/server/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>some-nonsense</application>
     <threadsafe>true</threadsafe>
 
     <system-properties>

--- a/src/test/resources/projects/clientserver/server/src/main/webapp/WEB-INF/web.xml
+++ b/src/test/resources/projects/clientserver/server/src/main/webapp/WEB-INF/web.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?><web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
     <servlet>
-        <servlet-name>SystemServiceServlet</servlet-name>
-        <servlet-class>com.google.api.server.spi.SystemServiceServlet</servlet-class>
+        <servlet-name>EndpointsServlet</servlet-name>
+        <servlet-class>com.google.api.server.spi.EndpointsServlet</servlet-class>
         <init-param>
             <param-name>services</param-name>
             <param-value>com.example.Test, com.example.Test2</param-value>
         </init-param>
     </servlet>
     <servlet-mapping>
-        <servlet-name>SystemServiceServlet</servlet-name>
-        <url-pattern>/_ah/spi/*</url-pattern>
+        <servlet-name>EndpointsServlet</servlet-name>
+        <url-pattern>/_ah/api/*</url-pattern>
     </servlet-mapping>
 </web-app>

--- a/src/test/resources/projects/server/build.gradle
+++ b/src/test/resources/projects/server/build.gradle
@@ -20,7 +20,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.1.0"
+    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.3.0"
   }
 }
 
@@ -40,9 +40,9 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "com.google.endpoints:endpoints-framework:2.0.0"
+  compile "com.google.endpoints:endpoints-framework:2.0.7" // use latest
   compile 'javax.servlet:servlet-api:2.5'
   compile 'javax.inject:javax.inject:1'
 }
 
-
+/*endpoints-plugin-configuration*/

--- a/src/test/resources/projects/server/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/test/resources/projects/server/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>some-nonsense</application>
+
+    <!--application-->
     <threadsafe>true</threadsafe>
 
     <system-properties>

--- a/src/test/resources/projects/server/src/main/webapp/WEB-INF/web.xml
+++ b/src/test/resources/projects/server/src/main/webapp/WEB-INF/web.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?><web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.5" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
     <servlet>
-        <servlet-name>SystemServiceServlet</servlet-name>
-        <servlet-class>com.google.api.server.spi.SystemServiceServlet</servlet-class>
+        <servlet-name>EndpointsServlet</servlet-name>
+        <servlet-class>com.google.api.server.spi.EndpointsServlet</servlet-class>
         <init-param>
             <param-name>services</param-name>
             <param-value>com.example.Test</param-value>
         </init-param>
     </servlet>
     <servlet-mapping>
-        <servlet-name>SystemServiceServlet</servlet-name>
-        <url-pattern>/_ah/spi/*</url-pattern>
+        <servlet-name>EndpointsServlet</servlet-name>
+        <url-pattern>/_ah/api/*</url-pattern>
     </servlet-mapping>
 </web-app>


### PR DESCRIPTION
Allow users to specify hostname (like `myapp.appspot.com`) to set the default root-url for clients and discovery docs. It's never been needed, but it is a convenience option for developers that want a working default. Users can still use `.setRootUrl` to override the default when making calls with the client library.

This used to be derived from the `<application>` tag in appengine-web.xml, but we are phasing out that tag in favor of specifying the project in `gcloud app deploy --project`.