### PR TITLE
Scan classpath for service (API) classes listed in @WebService annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,14 @@ dependencies {
   compile gradleApi()
   compile "com.google.endpoints:endpoints-framework-tools:2.0.7"
   compile "com.google.guava:guava:19.0"
+  compile "org.reflections:reflections:0.9.11"
+  compile "org.apache.maven:maven-artifact:3.5.0"
 
   testCompile 'commons-io:commons-io:2.4'
   testCompile 'org.hamcrest:hamcrest-library:1.3'
   testCompile 'org.mockito:mockito-core:2.1.0'
   testCompile 'junit:junit:4.12'
+  testCompile 'javax.servlet:javax.servlet-api:3.1.0'
 }
 
 jar {

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateClientLibsTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateClientLibsTask.java
@@ -18,10 +18,12 @@ package com.google.cloud.tools.gradle.endpoints.framework.server.task;
 
 import com.google.api.server.spi.tools.EndpointsTool;
 import com.google.api.server.spi.tools.GetClientLibAction;
+import com.google.cloud.tools.gradle.endpoints.framework.server.task.scan.AnnotationServletScanner;
 import com.google.common.base.Strings;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -144,6 +146,9 @@ public class GenerateClientLibsTask extends DefaultTask {
       params.add(basePath);
     }
     params.addAll(serviceClasses);
+    Collection<String> annotatedServiceClasses =
+        new AnnotationServletScanner(getProject()).findApiClassesInSourceAnnotations();
+    params.addAll(annotatedServiceClasses);
 
     new EndpointsTool().execute(params.toArray(new String[params.size()]));
   }

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateDiscoveryDocsTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateDiscoveryDocsTask.java
@@ -18,10 +18,12 @@ package com.google.cloud.tools.gradle.endpoints.framework.server.task;
 
 import com.google.api.server.spi.tools.EndpointsTool;
 import com.google.api.server.spi.tools.GetDiscoveryDocAction;
+import com.google.cloud.tools.gradle.endpoints.framework.server.task.scan.AnnotationServletScanner;
 import com.google.common.base.Strings;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -133,6 +135,9 @@ public class GenerateDiscoveryDocsTask extends DefaultTask {
       params.add(basePath);
     }
     params.addAll(getServiceClasses());
+    Collection<String> annotatedServiceClasses =
+        new AnnotationServletScanner(getProject()).findApiClassesInSourceAnnotations();
+    params.addAll(annotatedServiceClasses);
 
     new EndpointsTool().execute(params.toArray(new String[params.size()]));
   }

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateOpenApiDocsTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/GenerateOpenApiDocsTask.java
@@ -18,10 +18,12 @@ package com.google.cloud.tools.gradle.endpoints.framework.server.task;
 
 import com.google.api.server.spi.tools.EndpointsTool;
 import com.google.api.server.spi.tools.GetOpenApiDocAction;
+import com.google.cloud.tools.gradle.endpoints.framework.server.task.scan.AnnotationServletScanner;
 import com.google.common.base.Strings;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -134,6 +136,9 @@ public class GenerateOpenApiDocsTask extends DefaultTask {
       params.add(basePath);
     }
     params.addAll(getServiceClasses());
+    Collection<String> annotatedServiceClasses =
+        new AnnotationServletScanner(getProject()).findApiClassesInSourceAnnotations();
+    params.addAll(annotatedServiceClasses);
 
     new EndpointsTool().execute(params.toArray(new String[params.size()]));
   }

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/scan/AnnotationServletScanner.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/scan/AnnotationServletScanner.java
@@ -1,0 +1,123 @@
+package com.google.cloud.tools.gradle.endpoints.framework.server.task.scan;
+
+import static java.util.Collections.emptySet;
+import static org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collection;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
+import org.gradle.api.specs.Spec;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ConfigurationBuilder;
+
+/**
+ * Scans compile classpath and returns list of endpoints API classes mentioned
+ * in @WebServlet\@WebInitParam annotations.
+ */
+public class AnnotationServletScanner {
+
+  private final Project project;
+  private final Configuration compileConfiguration;
+
+  /** The only one constructor. */
+  public AnnotationServletScanner(Project project) {
+    this.project = project;
+    compileConfiguration =
+        project.getConfigurations().getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME);
+  }
+
+  /** Performs real classpath scan. */
+  public Collection<String> findApiClassesInSourceAnnotations() {
+    String servletApiVersion = getLatestServletApiVersion();
+    if (StringUtils.isEmpty(servletApiVersion)) {
+      return emptySet();
+    }
+
+    URL projectClassesUrl = toUrl(new File(project.getBuildDir().getPath() + "/classes/java/main"));
+    URL servletJarUrl = toUrl(getServletApiDependencyJar(servletApiVersion));
+    URL endpointsUrl = toUrl(getEndpointsJar());
+    URLClassLoader classLoader =
+        URLClassLoader.newInstance(new URL[] {projectClassesUrl, servletJarUrl, endpointsUrl});
+    Set<Class<?>> servletClasses = getServletClasses(projectClassesUrl, classLoader);
+    if (servletClasses.isEmpty()) {
+      return emptySet();
+    }
+    return new ApiClassesLookup(servletClasses, classLoader).apiClassNames();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Set<Class<?>> getServletClasses(URL projectClassesLocation, URLClassLoader classLoader) {
+    Class<?> httpServletClass;
+    try {
+      httpServletClass = classLoader.loadClass("com.google.api.server.spi.EndpointsServlet");
+    } catch (ClassNotFoundException e) {
+      throw new GradleException("Cannot load class com.google.api.server.spi.EndpointsServlet", e);
+    }
+
+    Reflections reflections =
+        new Reflections(
+            new ConfigurationBuilder()
+                .addClassLoader(classLoader)
+                .setScanners(new SubTypesScanner(true))
+                .addUrls(projectClassesLocation));
+
+    return (Set<Class<?>>) reflections.getSubTypesOf(httpServletClass);
+  }
+
+  private File getServletApiDependencyJar(final String version) {
+    Set<File> files =
+        compileConfiguration.files(
+            new Spec<Dependency>() {
+              @Override
+              public boolean isSatisfiedBy(Dependency element) {
+                return version.equals(element.getVersion());
+              }
+            });
+    if (files.isEmpty()) {
+      throw new GradleException("Cannot find servlet-api jar on classpath");
+    }
+    return files.iterator().next();
+  }
+
+  private File getEndpointsJar() {
+    return compileConfiguration.files(new EndpointsFrameworkDependencySpec()).iterator().next();
+  }
+
+  /** Returns latest version of Servlet API available in app compile-time classpath. */
+  private String getLatestServletApiVersion() {
+    DomainObjectSet<DefaultExternalModuleDependency> servletApiDependencies =
+        project
+            .getConfigurations()
+            .getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME)
+            .getAllDependencies()
+            .withType(DefaultExternalModuleDependency.class)
+            .matching(new ServletApiDependencyScan());
+    SortedSet<DefaultArtifactVersion> foundServletApiVersions = new TreeSet<>();
+    for (DefaultExternalModuleDependency dependency : servletApiDependencies) {
+      foundServletApiVersions.add(new DefaultArtifactVersion(dependency.getVersion()));
+    }
+    return foundServletApiVersions.last().toString();
+  }
+
+  private static URL toUrl(File file) {
+    try {
+      return file.toURI().toURL();
+    } catch (MalformedURLException e) {
+      throw new GradleException("Cannot compute URL for file");
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/scan/ApiClassesLookup.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/scan/ApiClassesLookup.java
@@ -1,0 +1,77 @@
+package com.google.cloud.tools.gradle.endpoints.framework.server.task.scan;
+
+import com.google.common.collect.ImmutableSet;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.GradleException;
+
+public class ApiClassesLookup {
+
+  private static final Class[] EMPTY_CLASS_ARRAY = {};
+  private static final String JAVAX_WEB_INIT_PARAM = "javax.servlet.annotation.WebInitParam";
+  private static final String JAVAX_WEB_SERVLET = "javax.servlet.annotation.WebServlet";
+
+  private final Collection<Class<?>> classesToScan;
+  private final Method nameMethod;
+  private final Method valueMethod;
+
+  /** The only one constructor. */
+  public ApiClassesLookup(Collection<Class<?>> classesToScan, ClassLoader classLoader) {
+    this.classesToScan = classesToScan;
+    try {
+      Class<?> webInitParamAnnotationClass = classLoader.loadClass(JAVAX_WEB_INIT_PARAM);
+      nameMethod = webInitParamAnnotationClass.getDeclaredMethod("name", EMPTY_CLASS_ARRAY);
+      valueMethod = webInitParamAnnotationClass.getDeclaredMethod("value", EMPTY_CLASS_ARRAY);
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      throw new GradleException("Failed to read class metadata for " + JAVAX_WEB_INIT_PARAM, e);
+    }
+  }
+
+  /** Returns list of API class names found during classpath scan. */
+  public Collection<String> apiClassNames() {
+
+    ImmutableSet.Builder<String> resultBuilder = ImmutableSet.builder();
+    for (Class<?> servletClass : classesToScan) {
+      for (Annotation annotation : servletClass.getAnnotations()) {
+        Class<? extends Annotation> webServletAnnotationClass = annotation.annotationType();
+        if (JAVAX_WEB_SERVLET.equals(webServletAnnotationClass.getName())) {
+          for (Object webInitParam :
+              getDeclaredInitParams(servletClass, webServletAnnotationClass)) {
+            if ("services".equals(invokeMethod(webInitParam, nameMethod))) {
+              String declaredServiceClassNames = invokeMethod(webInitParam, valueMethod).toString();
+              String[] split = StringUtils.split(declaredServiceClassNames, ",");
+              for (String declaredClass : split) {
+                resultBuilder.add(StringUtils.trim(declaredClass));
+              }
+            }
+          }
+        }
+      }
+    }
+    return resultBuilder.build();
+  }
+
+  private static Object invokeMethod(Object webInitParam, Method nameMethod) {
+    try {
+      return nameMethod.invoke(webInitParam);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new GradleException("Failed to read init params metadata", e);
+    }
+  }
+
+  private static Object[] getDeclaredInitParams(
+      Class<?> servletClass, Class<? extends Annotation> webServletAnnotationClass) {
+    Annotation webServletAnnotation = servletClass.getAnnotation(webServletAnnotationClass);
+    try {
+      Method initParams =
+          webServletAnnotationClass.getDeclaredMethod("initParams", EMPTY_CLASS_ARRAY);
+      return (Object[]) invokeMethod(webServletAnnotation, initParams);
+    } catch (NoSuchMethodException e) {
+      throw new GradleException(
+          "Failed to read init params metadata for class " + servletClass.getName(), e);
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/scan/EndpointsFrameworkDependencySpec.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/scan/EndpointsFrameworkDependencySpec.java
@@ -1,0 +1,12 @@
+package com.google.cloud.tools.gradle.endpoints.framework.server.task.scan;
+
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.specs.Spec;
+
+public class EndpointsFrameworkDependencySpec implements Spec<Dependency> {
+  @Override
+  public boolean isSatisfiedBy(Dependency element) {
+    return "com.google.endpoints".equals(element.getGroup())
+        && "endpoints-framework".equals(element.getName());
+  }
+}

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/scan/ServletApiDependencyScan.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/task/scan/ServletApiDependencyScan.java
@@ -1,0 +1,13 @@
+package com.google.cloud.tools.gradle.endpoints.framework.server.task.scan;
+
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
+import org.gradle.api.specs.Spec;
+
+public class ServletApiDependencyScan implements Spec<DefaultExternalModuleDependency> {
+  @Override
+  public boolean isSatisfiedBy(DefaultExternalModuleDependency dependency) {
+    return "javax.servlet".equals(dependency.getGroup())
+        && ("javax.servlet-api".equals(dependency.getName())
+            || "servlet-api".equals(dependency.getName()));
+  }
+}

--- a/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/ApiClassesLookupTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/ApiClassesLookupTest.java
@@ -1,0 +1,27 @@
+package com.google.cloud.tools.gradle.endpoints.framework;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.tools.gradle.endpoints.framework.server.task.scan.ApiClassesLookup;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import org.junit.Test;
+
+public class ApiClassesLookupTest {
+
+  private ApiClassesLookup testee =
+      new ApiClassesLookup(
+          ImmutableSet.of(TestAnnotatedServletAlpha.class, TestAnnotatedServletBeta.class),
+          getClass().getClassLoader());
+
+  private final Collection<String> expectedApiClasses =
+      ImmutableSet.of("expectedApiClassAlpha", "betaOne", "betaTwo");
+
+  public ApiClassesLookupTest() throws NoSuchMethodException, ClassNotFoundException {}
+
+  @Test
+  public void webServiceClassNames() throws Exception {
+    Collection<String> foundApiClasses = testee.apiClassNames();
+    assertEquals(expectedApiClasses, foundApiClasses);
+  }
+}

--- a/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/EndpointsServerPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/EndpointsServerPluginTest.java
@@ -25,14 +25,16 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.util.zip.ZipFile;
-import org.gradle.testkit.runner.BuildResult;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /** Test endpoints server plugin builds. */
+@RunWith(Parameterized.class)
 public class EndpointsServerPluginTest {
 
   private static final String DEFAULT_HOSTNAME = "myapi.appspot.com";
@@ -50,23 +52,26 @@ public class EndpointsServerPluginTest {
 
   @Rule public TemporaryFolder testProjectDir = new TemporaryFolder();
 
+  @Parameterized.Parameters
+  public static String[] serverProjectBaseDirs() {
+    return new String[] {"projects/server", "projects/server-servlet-3.0"};
+  }
+
+  @Parameterized.Parameter public String projectBaseDir;
+
   @Test
   public void testClientLibs() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .gradleRunnerArguments("endpointsClientLibs")
-            .build();
+    newTestProject().gradleRunnerArguments("endpointsClientLibs").build();
 
     assertClientLibGeneration(DEFAULT_URL_VARIABLE, null);
   }
 
   @Test
   public void testClientLibs_hostname() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .hostname("my.hostname.com")
-            .gradleRunnerArguments("endpointsClientLibs")
-            .build();
+    newTestProject()
+        .hostname("my.hostname.com")
+        .gradleRunnerArguments("endpointsClientLibs")
+        .build();
 
     assertClientLibGeneration(
         DEFAULT_URL_PREFIX + "\"https://my.hostname.com" + DEFAULT_BASEPATH + "/\";",
@@ -75,11 +80,10 @@ public class EndpointsServerPluginTest {
 
   @Test
   public void testClientLibs_basePath() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .basePath("/a/different/path")
-            .gradleRunnerArguments("endpointsClientLibs")
-            .build();
+    newTestProject()
+        .basePath("/a/different/path")
+        .gradleRunnerArguments("endpointsClientLibs")
+        .build();
 
     assertClientLibGeneration(
         DEFAULT_URL_PREFIX + "\"https://" + DEFAULT_HOSTNAME + "/a/different/path/\";",
@@ -88,11 +92,10 @@ public class EndpointsServerPluginTest {
 
   @Test
   public void testClientLibs_application() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .applicationId("gradle-test")
-            .gradleRunnerArguments("endpointsClientLibs")
-            .build();
+    newTestProject()
+        .applicationId("gradle-test")
+        .gradleRunnerArguments("endpointsClientLibs")
+        .build();
 
     assertClientLibGeneration(
         DEFAULT_URL_PREFIX + "\"https://gradle-test.appspot.com" + DEFAULT_BASEPATH + "/\";",
@@ -118,43 +121,37 @@ public class EndpointsServerPluginTest {
 
   @Test
   public void testDiscoveryDocs() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .gradleRunnerArguments("endpointsDiscoveryDocs")
-            .build();
+    newTestProject().gradleRunnerArguments("endpointsDiscoveryDocs").build();
 
     assertDiscoveryDocGeneration(DEFAULT_URL, null);
   }
 
   @Test
   public void testDiscoveryDocs_hostname() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .hostname("my.hostname.com")
-            .gradleRunnerArguments("endpointsDiscoveryDocs")
-            .build();
+    newTestProject()
+        .hostname("my.hostname.com")
+        .gradleRunnerArguments("endpointsDiscoveryDocs")
+        .build();
 
     assertDiscoveryDocGeneration("https://my.hostname.com/_ah/api", DEFAULT_URL);
   }
 
   @Test
   public void testDiscoveryDocs_basePath() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .basePath("/a/different/path")
-            .gradleRunnerArguments("endpointsDiscoveryDocs")
-            .build();
+    newTestProject()
+        .basePath("/a/different/path")
+        .gradleRunnerArguments("endpointsDiscoveryDocs")
+        .build();
 
     assertDiscoveryDocGeneration("https://" + DEFAULT_HOSTNAME + "/a/different/path", DEFAULT_URL);
   }
 
   @Test
   public void testDiscoveryDocs_application() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .applicationId("gradle-test")
-            .gradleRunnerArguments("endpointsDiscoveryDocs")
-            .build();
+    newTestProject()
+        .applicationId("gradle-test")
+        .gradleRunnerArguments("endpointsDiscoveryDocs")
+        .build();
 
     assertDiscoveryDocGeneration("https://gradle-test.appspot.com/_ah/api", DEFAULT_URL);
   }
@@ -170,53 +167,52 @@ public class EndpointsServerPluginTest {
 
   @Test
   public void testOpenApiDocs() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .gradleRunnerArguments("endpointsOpenApiDocs")
-            .build();
+    newTestProject().gradleRunnerArguments("endpointsOpenApiDocs").build();
 
     assertOpenApiDocGeneration(DEFAULT_HOSTNAME, null);
   }
 
   @Test
   public void testOpenApiDocs_hostname() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .hostname("my.hostname.com")
-            .gradleRunnerArguments("endpointsOpenApiDocs")
-            .build();
+    newTestProject()
+        .hostname("my.hostname.com")
+        .gradleRunnerArguments("endpointsOpenApiDocs")
+        .build();
 
     assertOpenApiDocGeneration("my.hostname.com", DEFAULT_HOSTNAME);
   }
 
   @Test
   public void testOpenApiDocs_basePath() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .basePath("/a/different/path")
-            .gradleRunnerArguments("endpointsOpenApiDocs")
-            .build();
+    newTestProject()
+        .basePath("/a/different/path")
+        .gradleRunnerArguments("endpointsOpenApiDocs")
+        .build();
 
     assertOpenApiDocGeneration("/a/different/path", DEFAULT_BASEPATH);
   }
 
   @Test
   public void testOpenApiDocs_application() throws IOException, URISyntaxException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot(), "projects/server")
-            .applicationId("gradle-test")
-            .gradleRunnerArguments("endpointsOpenApiDocs")
-            .build();
+    newTestProject()
+        .applicationId("gradle-test")
+        .gradleRunnerArguments("endpointsOpenApiDocs")
+        .build();
 
     assertOpenApiDocGeneration("gradle-test.appspot.com", DEFAULT_HOSTNAME);
   }
 
   private void assertOpenApiDocGeneration(String expected, String unexpected) throws IOException {
     File openApiDoc = new File(testProjectDir.getRoot(), OPEN_API_DOC_PATH);
+    Assert.assertTrue("OpenApiDoc file does not exist: " + OPEN_API_DOC_PATH, openApiDoc.exists());
     String openApi = Files.toString(openApiDoc, Charsets.UTF_8);
     Assert.assertThat(openApi, CoreMatchers.containsString(expected));
     if (unexpected != null) {
       Assert.assertThat(openApi, CoreMatchers.not(CoreMatchers.containsString(unexpected)));
     }
+  }
+
+  private TestProject newTestProject() {
+    return new TestProject(testProjectDir.getRoot(), projectBaseDir);
   }
 }

--- a/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/TestAnnotatedServletAlpha.java
+++ b/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/TestAnnotatedServletAlpha.java
@@ -1,0 +1,7 @@
+package com.google.cloud.tools.gradle.endpoints.framework;
+
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+
+@WebServlet(initParams = {@WebInitParam(name = "services", value = "expectedApiClassAlpha")})
+class TestAnnotatedServletAlpha {}

--- a/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/TestAnnotatedServletBeta.java
+++ b/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/TestAnnotatedServletBeta.java
@@ -1,0 +1,7 @@
+package com.google.cloud.tools.gradle.endpoints.framework;
+
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+
+@WebServlet(initParams = {@WebInitParam(name = "services", value = "betaOne, betaTwo")})
+class TestAnnotatedServletBeta {}

--- a/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/TestProject.java
+++ b/src/test/java/com/google/cloud/tools/gradle/endpoints/framework/TestProject.java
@@ -76,6 +76,8 @@ public class TestProject {
         .withProjectDir(testDir)
         .withPluginClasspath()
         .withArguments(gradleRunnerArgs)
+        .withDebug(true)
+        .forwardOutput()
         .build();
   }
 

--- a/src/test/resources/projects/server-servlet-3.0/build.gradle
+++ b/src/test/resources/projects/server-servlet-3.0/build.gradle
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath "com.google.cloud.tools:appengine-gradle-plugin:1.3.0"
+  }
+}
+
+plugins {
+  id 'java'
+  id 'war'
+  id 'com.google.cloud.tools.endpoints-framework-server'
+}
+
+apply plugin: 'com.google.cloud.tools.appengine'
+
+repositories {
+  mavenCentral()
+}
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+dependencies {
+  compile "com.google.endpoints:endpoints-framework:2.0.7" // use latest
+  compile 'javax.servlet:javax.servlet-api:3.1.0'
+  compile 'javax.inject:javax.inject:1'
+}
+
+endpointsServer {
+  serviceClasses = ["com.example.Test"]
+}
+
+/*endpoints-plugin-hostname*/
+/*endpoints-plugin-basePath*/

--- a/src/test/resources/projects/server-servlet-3.0/src/main/java/com/example/MyBean.java
+++ b/src/test/resources/projects/server-servlet-3.0/src/main/java/com/example/MyBean.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+public class MyBean {
+
+  public String string;
+
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+}

--- a/src/test/resources/projects/server-servlet-3.0/src/main/java/com/example/Test.java
+++ b/src/test/resources/projects/server-servlet-3.0/src/main/java/com/example/Test.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+import com.google.api.server.spi.config.ApiNamespace;
+import javax.inject.Named;
+
+@Api(
+  name = "testApi",
+  version = "v1",
+  namespace =
+      @ApiNamespace(ownerDomain = "example.com", ownerName = "example.com", packagePath = "")
+)
+public class Test {
+
+  @ApiMethod(name = "echo")
+  public MyBean echo(@Named("name") String name) {
+    MyBean response = new MyBean();
+    response.setString("ECHO " + name);
+
+    return response;
+  }
+}

--- a/src/test/resources/projects/server-servlet-3.0/src/main/java/com/example/TestByAnnotationConfig.java
+++ b/src/test/resources/projects/server-servlet-3.0/src/main/java/com/example/TestByAnnotationConfig.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+import com.google.api.server.spi.config.ApiNamespace;
+import javax.inject.Named;
+
+@Api(
+  name = "testApi",
+  version = "v1",
+  namespace =
+      @ApiNamespace(ownerDomain = "example.com", ownerName = "example.com", packagePath = "")
+)
+public class TestByAnnotationConfig {
+
+  @ApiMethod(name = "echoTwo")
+  public MyBean echoTwo(@Named("name") String name) {
+    MyBean response = new MyBean();
+    response.setString("ECHO " + name);
+
+    return response;
+  }
+}

--- a/src/test/resources/projects/server-servlet-3.0/src/main/java/com/example/TestServlet.java
+++ b/src/test/resources/projects/server-servlet-3.0/src/main/java/com/example/TestServlet.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.api.server.spi.EndpointsServlet;
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+
+@WebServlet(
+  name = "hello",
+  value = "/_ah/api/*",
+  initParams = {@WebInitParam(name = "services", value = "com.example.TestByAnnotationConfig")}
+)
+public class TestServlet extends EndpointsServlet {}

--- a/src/test/resources/projects/server-servlet-3.0/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/test/resources/projects/server-servlet-3.0/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+
+    <!--application-->
+    <threadsafe>true</threadsafe>
+
+    <system-properties>
+        <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+    </system-properties>
+
+    <static-files/>
+</appengine-web-app>

--- a/src/test/resources/projects/server-servlet-3.0/src/main/webapp/WEB-INF/logging.properties
+++ b/src/test/resources/projects/server-servlet-3.0/src/main/webapp/WEB-INF/logging.properties
@@ -1,0 +1,13 @@
+# A default java.util.logging configuration.
+# (All App Engine logging is through java.util.logging by default).
+#
+# To use this configuration, copy it into your application's WEB-INF
+# folder and add the following to your appengine-web.xml:
+# 
+# <system-properties>
+#   <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+# </system-properties>
+#
+
+# Set the default logging level for all loggers to WARNING
+.level = WARNING


### PR DESCRIPTION
Support for Servlet 3.0
Scan project sources for @WebService-annotated endpoints servlets (child classes of EndpointsServlet) and add found API classes (listed in servlet init param named "services") to docs\libs generated by endpoints plugin.