### PR TITLE
Updates endpoints-framework-tools version to 2.0.9.

### DIFF
--- a/ANDROID_README.md
+++ b/ANDROID_README.md
@@ -54,7 +54,7 @@ dependencies {
   // compile 'com.google.appengine:appengine-endpoints-deps:1.9.51'
   ... 
   // add these (inject needs to be explicitly included now)
-  compile 'com.google.endpoints:endpoints-framework:2.0.7'
+  compile 'com.google.endpoints:endpoints-framework:2.0.9'
   compile 'javax.inject:javax.inject:1'
   ...
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## 1.0.3
+### Changed
+- Updated endpoints-framework-tools to version 2.0.9 ([#70](https://github.com/GoogleCloudPlatform/endpoints-framework-maven-plugin/pull/70))
+
 ## 1.0.2
 ### Added
 - Add basePath to openApiDocs, clientLibs, and discoveryDocs generation ([#54](https://github.com/GoogleCloudPlatform/endpoints-framework-gradle-plugin/issues/54))

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ version = '1.0.3-SNAPSHOT'
 dependencies {
   compile localGroovy()
   compile gradleApi()
-  compile "com.google.endpoints:endpoints-framework-tools:2.0.7"
+  compile "com.google.endpoints:endpoints-framework-tools:2.0.9"
   compile "com.google.guava:guava:19.0"
 
   testCompile 'commons-io:commons-io:2.4'

--- a/src/test/resources/projects/clientserver/server/build.gradle
+++ b/src/test/resources/projects/clientserver/server/build.gradle
@@ -24,7 +24,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "com.google.endpoints:endpoints-framework:2.0.7" // use latest
+  compile "com.google.endpoints:endpoints-framework:+" // use latest
   compile "com.google.appengine:appengine-api-1.0-sdk:+" // use latest
   compile 'javax.servlet:servlet-api:2.5'
   compile 'javax.inject:javax.inject:1'

--- a/src/test/resources/projects/clientserver/server/build.gradle
+++ b/src/test/resources/projects/clientserver/server/build.gradle
@@ -24,7 +24,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "com.google.endpoints:endpoints-framework:+" // use latest
+  compile "com.google.endpoints:endpoints-framework:2.0.9" // use latest
   compile "com.google.appengine:appengine-api-1.0-sdk:+" // use latest
   compile 'javax.servlet:servlet-api:2.5'
   compile 'javax.inject:javax.inject:1'

--- a/src/test/resources/projects/server/build.gradle
+++ b/src/test/resources/projects/server/build.gradle
@@ -40,7 +40,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "com.google.endpoints:endpoints-framework:2.0.7" // use latest
+  compile "com.google.endpoints:endpoints-framework:+" // use latest
   compile 'javax.servlet:servlet-api:2.5'
   compile 'javax.inject:javax.inject:1'
 }

--- a/src/test/resources/projects/server/build.gradle
+++ b/src/test/resources/projects/server/build.gradle
@@ -40,7 +40,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile "com.google.endpoints:endpoints-framework:+" // use latest
+  compile "com.google.endpoints:endpoints-framework:2.0.9" // use latest
   compile 'javax.servlet:servlet-api:2.5'
   compile 'javax.inject:javax.inject:1'
 }


### PR DESCRIPTION
Mirrors the same version update in the endpoints-framework-maven-plugin: https://github.com/GoogleCloudPlatform/endpoints-framework-maven-plugin/pull/44