### PR TITLE
Replace setArchiveName with getArchiveFileName().set()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ Android Studio users see [transition guide](ANDROID_README.md).
 
 # Requirements
 
-[Gradle](http://gradle.org) is required to build and run the plugin.
+[Gradle](http://gradle.org) is required to build and run the plugin. The table below shows the compatibility with Gradle version.
+
+<!-- TODO: Remove "(not yet released)" once we release a new version -->
+
+| Gradle version | endpoints-framework-gradle-plugin version |
+| ------------- | ------------- |
+| 7.x - | 2.2.0 or higher (not yet released) |
+| 4.x - 6.x | 2.1.0 or lower |
 
 # How to use
 

--- a/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/EndpointsServerPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/endpoints/framework/server/EndpointsServerPlugin.java
@@ -114,7 +114,9 @@ public class EndpointsServerPlugin implements Plugin<Project> {
             Zip discoveryDocArchive = project.getTasks().create("_zipDiscoveryDocs", Zip.class);
             discoveryDocArchive.dependsOn(GENERATE_DISCOVERY_DOC_TASK);
             discoveryDocArchive.from(extension.getDiscoveryDocDir());
-            discoveryDocArchive.setArchiveName(project.getName() + "-" + "discoveryDocs.zip");
+            discoveryDocArchive
+                .getArchiveFileName()
+                .set(project.getName() + "-" + "discoveryDocs.zip");
 
             project.getArtifacts().add(ARTIFACT_CONFIGURATION, discoveryDocArchive);
           }


### PR DESCRIPTION
setArchiveName was deprecated in favor of getArchiveName.

Fixes https://github.com/GoogleCloudPlatform/endpoints-framework-gradle-plugin/issues/107


The deprecated `setArchiveName` is now alias to `getArchiveFileName()` and `set()`. Reading the implementation of `setArchiveName` and `getArchiveFileName()`:

```

    /**
     * Sets the archive name.
     *
     * @param name the archive name.
     * @deprecated Use {@link #getArchiveFileName()}
     */
    @Deprecated
    public void setArchiveName(String name) {
        DeprecationLogger.deprecateProperty(AbstractArchiveTask.class, "archiveName").replaceWith("archiveFileName")
            .willBeRemovedInGradle7()
            .withDslReference()
            .nagUser();
        archiveName.convention(name);
        archiveName.set(name);
    }

    /**
     * Returns the archive name. If the name has not been explicitly set, the pattern for the name is:
     * <code>[archiveBaseName]-[archiveAppendix]-[archiveVersion]-[archiveClassifier].[archiveExtension]</code>
     *
     * @return the archive name.
     * @since 5.1
     */
    @Internal("Represented as part of archiveFile")
    public Property<String> getArchiveFileName() {
        return archiveName;
    }
```

Implementation-wise, The old `setArchiveName` also calls `archiveName.convention(name)`. But this method is "The convention is used when no value has been set for this property." ([doc](https://docs.gradle.org/6.9/javadoc/org/gradle/api/provider/Property.html#convention-T-)). In this case we set the value there so no need to call the `convention()` method.